### PR TITLE
add grafana websocket reverse proxy, update to home-assistant:2023.4.6, allow unsigned grafana plugin descrete

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -231,7 +231,7 @@
     - name: docker; create container homeassistant
       docker_container:
         name: homeassistant
-        image: "{{ nexus_docker_repo }}homeassistant/home-assistant:2023.4.1"
+        image: "{{ nexus_docker_repo }}homeassistant/home-assistant:2023.4.6"
         state: started
         restart_policy: unless-stopped
         hostname: homeassistant.invadelabs.com
@@ -263,6 +263,7 @@
         env:
           GF_SECURITY_ALLOW_EMBEDDING: "true"
           GF_INSTALL_PLUGINS: "natel-discrete-panel"
+          GF_ALLOW_LOADING_UNSIGNED_PLUGINS: "natel-discrete-panel"
         volumes:
           - "/srv/grafana:/var/lib/grafana"
         ports:

--- a/templates/etc/nginx/conf.d/grafana.invadelabs.com.conf.j2
+++ b/templates/etc/nginx/conf.d/grafana.invadelabs.com.conf.j2
@@ -26,6 +26,17 @@ server {
         proxy_set_header Host $http_host; # https://github.com/grafana/grafana/issues/45117#issuecomment-1033842787
     }
 
+    location /api/live/ {
+	proxy_pass       http://172.17.0.1:3000;
+        proxy_set_header X-Forwarded-Host $host:$server_port;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection  "upgrade";
+        proxy_set_header Host $host;
+    }
+
     # wildcard cert
     ssl_certificate /etc/letsencrypt/live/invadelabs.com-0001/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/invadelabs.com-0001/privkey.pem;


### PR DESCRIPTION
- add grafana websocket reverse proxy
- update to home-assistant:2023.4.6, allow unsigned grafana plugin descrete
